### PR TITLE
g5: enable CNE and set DPM to fully enabled

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -28,8 +28,7 @@ persist.camera.dual.camera=1
 ro.camera.notify_nfc=1
 
 # CNE and DPM
-persist.cne.feature=0
-persist.dpm.feature=5
+persist.cne.feature=1
 persist.dpm.nsrm.bkg.evt=3955
 persist.env.fastdorm.enabled=false
 


### PR DESCRIPTION
- setting the CNE prop to 1 will enable CNE
- removing the DPM prop will automatically set the value to 7, which enables all DPM features

Signed-off-by: Alex Naidis alex.naidis@linux.com
