### PR TITLE
g5: add missing gps prop

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -50,6 +50,7 @@ persist.audio.fluence.speaker=true
 
 # GPS
 persist.gps.qc_nlp_in_use=1
+persist.loc.nlp_name=com.qualcomm.location
 ro.gps.agps_provider=1
 
 # OpenGLES


### PR DESCRIPTION
- needed if we want to use QC NLP for location
  REF: BSP_PATH/gps/Android.mk

Signed-off-by: Alex Naidis alex.naidis@linux.com
