### PR TITLE
g5: trash proposed sched boosting during boot

### DIFF
--- a/rootdir/etc/init.qcom.power.rc
+++ b/rootdir/etc/init.qcom.power.rc
@@ -130,6 +130,7 @@ on enable-low-power
     write /sys/module/cpu_boost/parameters/input_boost_ms 40
 
     # Set big.LITTLE scheduler parameters
+    write /proc/sys/kernel/sched_boost 0
     write /proc/sys/kernel/sched_migration_fixup 1
     write /proc/sys/kernel/sched_downmigrate 45
     write /proc/sys/kernel/sched_upmigrate 45
@@ -171,11 +172,9 @@ on enable-low-power
     #start iop
 
 on class_start:late_start
-    write /proc/sys/kernel/sched_boost 1
     trigger enable-low-power
 
 on property:dev.bootcomplete=1
-    write /proc/sys/kernel/sched_boost 0
     setprop sys.io.scheduler "bfq"
 
 on property:init.svc.recovery=running


### PR DESCRIPTION
- this is completely broken as disabling sched_boost after boot is completed fails and thus is stays enabled
- Even if that would be functional, this implementation wouldn't really make a difference, since the timeframe from late_start to the completion of boot is very small
  -> completely trash sched boosting since the boot time of the device is acceptable.

Signed-off-by: Alex Naidis alex.naidis@linux.com
